### PR TITLE
fix: 修复 SwitchSettingCard 因 configItem 类型错误导致启动崩溃

### DIFF
--- a/src/app/view/setting_interface.py
+++ b/src/app/view/setting_interface.py
@@ -57,9 +57,9 @@ class SettingInterface(ScrollArea):
             FIF.TRANSPARENT,
             self.tr("Mica 效果"),
             self.tr("在窗口和表面上应用半透明效果"),
-            isWin11(),
-            self.personalGroup,
+            parent=self.personalGroup,
         )
+        self.micaCard.setChecked(isWin11())
 
         self.aboutGroup = SettingCardGroup(self.tr("关于"), self.scrollWidget)
         self.aboutCard = PrimaryPushSettingCard(


### PR DESCRIPTION
## Summary
- 修复 SettingInterface 中 SwitchSettingCard 构造时将 isWin11() (bool) 作为 configItem 位置参数传入，导致库内部调用 configItem.value 抛出 AttributeError: 'bool' object has no attribute 'value' 的启动崩溃问题
- 改为用 parent= 关键字参数跳过 configItem，再通过 setChecked() 手动设置初始状态，与同文件 askDownloadLocationCard 写法保持一致
应该可以兼容win11了