### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,9 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Check code


### PR DESCRIPTION
Potential fix for [https://github.com/123panNextGen/123pan/security/code-scanning/1](https://github.com/123panNextGen/123pan/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: define it at the workflow root (top-level), since there is only one job and no job-specific elevated needs are shown. Use:

- `contents: read`

This preserves current functionality (checkout and read-based CI operations) while satisfying CodeQL and least-privilege requirements.

Edit file:
- `.github/workflows/check.yml`
- Insert `permissions:` between the trigger section and `jobs:` (after line 8 in the provided snippet).

No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
