### PR TITLE
fix: API 请求失败时切换备用域名

### DIFF
--- a/src/app/api/session.py
+++ b/src/app/api/session.py
@@ -35,12 +35,39 @@ from .model import (
 )
 
 BASE_URL = "https://www.123pan.cn"
+FALLBACK_BASE_URL = "https://api.123278.com"
 # 二维码登录专用域名（web 端登录接口）
 LOGIN_BASE_URL = "https://login.123pan.com"
 
 # 预编译正则：解析 HTML body 中 href='...' 形式的下载链接
 # 避免每次调用 _resolve_download_url 时重复编译
 _HREF_URL_RE = re.compile(r"href='(https?://[^']+)'")
+
+
+class _ApiSession(requests.Session):
+    def __init__(self):
+        super().__init__()
+        self._use_fallback = False
+
+    def request(self, method, url, **kwargs):
+        parsed = urlparse(url)
+        is_primary_api = (
+            parsed.netloc == urlparse(BASE_URL).netloc and "/api/" in parsed.path
+        )
+        if not is_primary_api:
+            return super().request(method, url, **kwargs)
+
+        fallback_url = url.replace(BASE_URL, FALLBACK_BASE_URL, 1)
+        if self._use_fallback:
+            return super().request(method, fallback_url, **kwargs)
+
+        try:
+            return super().request(method, url, **kwargs)
+        except requests.exceptions.ConnectionError as error:
+            logger.warning("API 请求失败，切换备用地址: %s", error)
+            response = super().request(method, fallback_url, **kwargs)
+            self._use_fallback = True
+            return response
 
 
 class NetSession:
@@ -51,14 +78,13 @@ class NetSession:
 
     def __init__(self):
         self._user_info: Optional[UserInfoModel] = None
-        self._http = requests.Session()
+        self._http = _ApiSession()
         self._http.headers.update(
             {
                 "accept-encoding": "gzip",
                 "content-type": "application/json",
                 "platform": "android",
                 "devicename": "Xiaomi",
-                "host": "www.123pan.cn",
                 "app-version": "61",
                 "x-app-version": "2.4.0",
             }

--- a/tests/integration/test_session.py
+++ b/tests/integration/test_session.py
@@ -121,6 +121,35 @@ class TestNetSessionHttp:
         assert session.authorization == "Bearer test_token"
 
     @responses.activate
+    def test_login_falls_back_after_network_error(self):
+        responses.post(
+            "https://www.123pan.cn/b/api/user/sign_in",
+            body=requests.exceptions.SSLError("wrong version number"),
+        )
+        responses.post(
+            "https://api.123278.com/b/api/user/sign_in",
+            json={"code": 200, "data": {"token": "test_token"}},
+            status=200,
+        )
+        responses.get(
+            "https://api.123278.com/api/ping",
+            json={"ok": True},
+            status=200,
+        )
+
+        session = NetSession()
+        result = session.login("test_user", "test_pass")
+        follow_up = session.http.get("https://www.123pan.cn/api/ping")
+
+        assert result.code == 200
+        assert follow_up.json() == {"ok": True}
+        assert [call.request.url for call in responses.calls] == [
+            "https://www.123pan.cn/b/api/user/sign_in",
+            "https://api.123278.com/b/api/user/sign_in",
+            "https://api.123278.com/api/ping",
+        ]
+
+    @responses.activate
     def test_login_invalid_credentials(self):
         responses.post(
             "https://www.123pan.cn/b/api/user/sign_in",
@@ -136,6 +165,10 @@ class TestNetSessionHttp:
     def test_login_network_error(self):
         responses.post(
             "https://www.123pan.cn/b/api/user/sign_in",
+            body=requests.exceptions.ConnectionError("connection refused"),
+        )
+        responses.post(
+            "https://api.123278.com/b/api/user/sign_in",
             body=requests.exceptions.ConnectionError("connection refused"),
         )
         session = NetSession()
@@ -375,6 +408,10 @@ class TestNetSessionModPid:
     def test_mod_pid_network_error(self):
         responses.post(
             "https://www.123pan.cn/b/api/file/mod_pid",
+            body=requests.exceptions.ConnectionError("connection refused"),
+        )
+        responses.post(
+            "https://api.123278.com/b/api/file/mod_pid",
             body=requests.exceptions.ConnectionError("connection refused"),
         )
         session = NetSession()


### PR DESCRIPTION
发生ssl或连接错误时，自动切换到 `api.123278.com`
切换后后续api请求继续使用备用地址

Fixes #97 