### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - "**"
 
+permissions:
+  contents: read
+
 jobs:
   mirror:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/123panNextGen/123pan/security/code-scanning/2](https://github.com/123panNextGen/123pan/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: define permissions at the workflow root (applies to all jobs unless overridden), with `contents: read` as the minimal required permission for `actions/checkout`.

**File to edit:** `.github/workflows/mirror.yaml`  
**Change:** insert:

```yaml
permissions:
  contents: read
```

immediately after the `on:` trigger section (before `jobs:`), so the whole workflow has explicit read-only repository contents access.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
